### PR TITLE
Fix typo in kernel build procedure

### DIFF
--- a/Notes/Archi OS Lesson 2.md
+++ b/Notes/Archi OS Lesson 2.md
@@ -222,6 +222,6 @@ Use the Gentoo Handbook for guidance on enabling necessary options in `menuconfi
 ```bash
 make -j2 # Use 2 cores for compilation 
 make && make modules_install # Compile and install the modules 
-date ; make -j2 && make modules install; date # Show time before and after compilation
+date ; make -j2 && make modules_install; date # Show time before and after compilation
 ```
 


### PR DESCRIPTION
A typo in the kernel build procedure was causing the following error : 

![image](https://github.com/user-attachments/assets/3dbe997a-b1da-40cd-acc6-fb841ba62413)

The build process should now run as expected.